### PR TITLE
Add tutorial examples

### DIFF
--- a/include/a64rf_api.h
+++ b/include/a64rf_api.h
@@ -58,7 +58,7 @@ static inline uint64_t read_d_vreg(const a64rf_state_t* state, a64rf_vreg_idx_t 
     }
     if (lane > 1) {
         // Handle error: invalid lane index
-        fprintf(stderr, "Invalid lane index %d for vreg d[]\n", lane);
+        fprintf(stderr, "Invalid lane index %zu for vreg d[]\n", lane);
         return 0;
     }
     return state->vreg[vreg_idx].d[lane];

--- a/tests/example001.c
+++ b/tests/example001.c
@@ -1,0 +1,33 @@
+/* example001.c - ADDS boundary example */
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "a64rf_types.h"
+#include "a64rf_api.h"
+#include "a64rf_op.h"
+
+#define DUMP_GPR(s, r)  print_val_gpr_to_hex(&(s), r)
+#define DUMP_NZCV(s)    printf("NZCV = N:%u Z:%u C:%u V:%u\n", \
+                               (s).nzcv.N, (s).nzcv.Z, \
+                               (s).nzcv.C, (s).nzcv.V)
+
+int main(void)
+{
+    a64rf_state_t s;
+    memset(&s, 0, sizeof s);
+
+    /* Stage 0: initial values */
+    write_val_gpr(&s, X0, 0xfffffffffffffff0ULL);
+    write_val_gpr(&s, X1, 0x20ULL);
+    write_val_gpr(&s, X2, 0ULL);
+    puts("=== Initial ===");
+    DUMP_GPR(s, X0);  DUMP_GPR(s, X1);  DUMP_NZCV(s);
+
+    /* Stage 1: ADDS overflow boundary */
+    puts("\n=== ADDS X2, X0, X1 ===");
+    adds_xform(&s, X2, X0, X1);
+    DUMP_GPR(s, X2);  DUMP_NZCV(s);
+
+    return 0;
+}

--- a/tests/example002.c
+++ b/tests/example002.c
@@ -1,0 +1,36 @@
+/* example002.c - ADCS and SUBS examples */
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "a64rf_types.h"
+#include "a64rf_api.h"
+#include "a64rf_op.h"
+
+#define DUMP_GPR(s, r)  print_val_gpr_to_hex(&(s), r)
+#define DUMP_NZCV(s)    printf("NZCV = N:%u Z:%u C:%u V:%u\n", \
+                               (s).nzcv.N, (s).nzcv.Z, \
+                               (s).nzcv.C, (s).nzcv.V)
+
+int main(void)
+{
+    a64rf_state_t s;
+    memset(&s, 0, sizeof s);
+
+    /* Prepare some values via ADDS */
+    write_val_gpr(&s, X0, 0x10ULL);
+    write_val_gpr(&s, X1, 0x10ULL);
+    adds_xform(&s, X2, X0, X1); /* result 0x20, C cleared */
+
+    /* Stage 2: ADCS chaining carry */
+    puts("=== ADCS X3, X2, X2 ===");
+    adcs_xform(&s, X3, X2, X2);
+    DUMP_GPR(s, X3);  DUMP_NZCV(s);
+
+    /* Stage 3: SUBS negative result */
+    puts("\n=== SUBS X4, X2, X3 ===");
+    subs_xform(&s, X4, X2, X3);
+    DUMP_GPR(s, X4);  DUMP_NZCV(s);
+
+    return 0;
+}

--- a/tests/example003.c
+++ b/tests/example003.c
@@ -1,0 +1,47 @@
+/* example003.c - SBCS, CMP/CMN and logical flag updates */
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "a64rf_types.h"
+#include "a64rf_api.h"
+#include "a64rf_op.h"
+
+#define DUMP_GPR(s, r)  print_val_gpr_to_hex(&(s), r)
+#define DUMP_NZCV(s)    printf("NZCV = N:%u Z:%u C:%u V:%u\n", \
+                               (s).nzcv.N, (s).nzcv.Z, \
+                               (s).nzcv.C, (s).nzcv.V)
+
+int main(void)
+{
+    a64rf_state_t s;
+    memset(&s, 0, sizeof s);
+
+    write_val_gpr(&s, X2, 0x10ULL);
+    write_val_gpr(&s, X3, 0x21ULL);
+
+    /* Stage 4: SBCS with borrow */
+    puts("=== SBCS X5, X3, X2 ===");
+    sbcs_xform(&s, X5, X3, X2);
+    DUMP_GPR(s, X5);  DUMP_NZCV(s);
+
+    /* Stage 5: CMP and CMN */
+    puts("\n=== CMP X3, X3 ===");
+    cmp_xform(&s, X3, X3);
+    DUMP_NZCV(s);
+
+    puts("\n=== CMN X3, X2 ===");
+    cmn_xform(&s, X3, X2);
+    DUMP_NZCV(s);
+
+    /* Stage 6: ANDS and EORS */
+    puts("\n=== ANDS X6, X3, X2 ===");
+    ands_xform(&s, X6, X3, X2);
+    DUMP_GPR(s, X6);  DUMP_NZCV(s);
+
+    puts("\n=== EORS X7, X3, X3 ===");
+    eors_xform(&s, X7, X3, X3);
+    DUMP_GPR(s, X7);  DUMP_NZCV(s);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `tests` directory with simple examples derived from `ref1.c`
- fix a format string in `a64rf_api.h`

## Testing
- `gcc -I include -Wall -Wextra -pedantic tests/example001.c -o /tmp/example001`
- `gcc -I include -Wall -Wextra -pedantic tests/example002.c -o /tmp/example002`
- `gcc -I include -Wall -Wextra -pedantic tests/example003.c -o /tmp/example003`


------
https://chatgpt.com/codex/tasks/task_e_684ef83849d08329a57344f0009dda1b