### PR TITLE
Mention new tests directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# A64RF Playground
+
+Welcome! This repository is a tiny sandbox for tinkering with ARM64 register snapshots.  If you enjoy low-level experiments, you might like these files.
+
+> **Heads up**: the instruction simulation core works, but many instructions still
+> aren't implemented. Expect gaps while we fill in the missing pieces over time.
+> The snapshot function also likes to misbehave occasionally, so treat results
+> as experimental.
+
+```
+\o/  Features
+-----------------
+* Snapshot helpers written in C
+* Macros to capture register state from assembly
+* Small demo programs
+* Extra sample programs live in `tests/`
+```
+
+To build the examples, grab a compiler that targets ARM64 and run a few clang commands (see `README.md`). Define `A64RF_TRACE` when you assemble to emit extra debug snapshots.
+
+Have fun exploring!
+
+


### PR DESCRIPTION
## Summary
- document the new `tests/` directory in the playful README
- delete unused README versions

## Testing
- `clang -Iinclude -c src/a64rf_dump.c src/a64rf_snap.c` *(fails: 'a64rf_state.h' file not found)*
- `clang -Iinclude ref1.c -o ref1`

------
https://chatgpt.com/codex/tasks/task_e_684ef6d8f6e883298c0f8bf08f084c67