### PR TITLE
Add BICS logical operation

### DIFF
--- a/include/a64rf_op.h
+++ b/include/a64rf_op.h
@@ -29,7 +29,7 @@ static inline void set_flags_logical(uint64_t res, nzcv_t *f)
     f->N = res >> 63;
     f->Z = (res == 0);
     f->C = 0;
-    f->V = 0;         /* 依規格，ANDS/BICS/EORS 把 C/V 置 0 */  /**/
+    f->V = 0;         /* 依規格，ANDS/BICS/EORS 把 C/V 置 0 */
 }
 
 
@@ -189,6 +189,21 @@ static inline void eors_xform(a64rf_state_t *s,
     uint64_t src_m = read_val_gpr(s, Xm);
 
     uint64_t result = src_n ^ src_m;
+
+    set_flags_logical(result, &s->nzcv);
+    write_val_gpr(s, Xd, result);
+}
+
+
+static inline void bics_xform(a64rf_state_t *s,
+                              const a64rf_gpr_idx_t Xd,
+                              const a64rf_gpr_idx_t Xn,
+                              const a64rf_gpr_idx_t Xm)
+{
+    uint64_t src_n = read_val_gpr(s, Xn);
+    uint64_t src_m = read_val_gpr(s, Xm);
+
+    uint64_t result = src_n & ~src_m;
 
     set_flags_logical(result, &s->nzcv);
     write_val_gpr(s, Xd, result);

--- a/tests/example004.c
+++ b/tests/example004.c
@@ -1,0 +1,43 @@
+/* example004.c - BICS instruction example */
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "a64rf_types.h"
+#include "a64rf_api.h"
+#include "a64rf_op.h"
+
+int main(void)
+{
+    a64rf_state_t s;
+    memset(&s, 0, sizeof s);
+
+    /* Scenario 1 */
+    write_val_gpr(&s, X1, 0xff00ff00ff00ff00ULL);
+    write_val_gpr(&s, X2, 0x00ff00ff00ff00ffULL);
+
+    puts("=== BICS X3, X1, X2 ===");
+    bics_xform(&s, X3, X1, X2);
+
+    print_val_gpr_to_hex(&s, X3);
+    print_nzcv(&s);
+
+    /* Scenario 2: zero result */
+    puts("\n=== BICS X4, X1, X1 ===");
+    bics_xform(&s, X4, X1, X1);
+
+    print_val_gpr_to_hex(&s, X4);
+    print_nzcv(&s);
+
+    /* Scenario 3: different operands */
+    write_val_gpr(&s, X5, 0xf0f0f0f0f0f0f0f0ULL);
+    write_val_gpr(&s, X6, 0x0f0f0f0f0f0f0f0fULL);
+
+    puts("\n=== BICS X7, X5, X6 ===");
+    bics_xform(&s, X7, X5, X6);
+
+    print_val_gpr_to_hex(&s, X7);
+    print_nzcv(&s);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement the missing BICS instruction in `a64rf_op.h`
- remove stray comment in `set_flags_logical`
- add a new `example004.c` demonstrating BICS, expanded with multiple scenarios

## Testing
- `gcc -std=c11 -Wall -Wextra -Iinclude tests/example004.c -o example004`
- `./example004`


------
https://chatgpt.com/codex/tasks/task_e_684efc5550248329aa4ae2c24bcef5f4