### PR TITLE
Add docs for core state structures

### DIFF
--- a/include/a64rf_types.h
+++ b/include/a64rf_types.h
@@ -4,6 +4,19 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+/*---------------------------------------------------------------------------
+ *  Basic type definitions for the ARM64 register framework.
+ *
+ *  Each structure mirrors part of the CPU state so that C helpers and
+ *  assembly snippets can easily exchange register snapshots.  The fields
+ *  include a few book-keeping values (such as the last writer's program
+ *  counter) that simplify debugging when running the unit tests.
+ *---------------------------------------------------------------------------*/
+
+/*
+ * Enumeration of the 31 general purpose registers.  The values map directly
+ * to the architectural X0–X30 register numbers used by AArch64 code.
+ */
 typedef enum a64rf_gpr_idx {
     X0  = 0,  X1,  X2,  X3,
     X4,       X5,  X6,  X7,
@@ -14,20 +27,35 @@ typedef enum a64rf_gpr_idx {
     X24,      X25, X26, X27,
     X28,      X29, X30,
 
-    GPR_IDX_MAX
+    GPR_IDX_MAX               /* Marks the end of the enum and is not a reg */
 } a64rf_gpr_idx_t;
 
 
+/* Number of entries in the general purpose register array. */
 #define GPR_COUNT   ((size_t)GPR_IDX_MAX)
 
-typedef union { struct { unsigned V:1,C:1,Z:1,N:1; }; uint32_t word; } nzcv_t;
+/* Representation of the NZCV condition flags used by the AArch64 ISA.  The
+ * structure view allows bitfield access while 'word' exposes the raw value. */
+typedef union {
+    struct { unsigned V:1, C:1, Z:1, N:1; };
+    uint32_t word;
+} nzcv_t;
 
+/*
+ * Metadata for a single general purpose register.  'val' holds the current
+ * 64-bit contents while 'last_writer_pc' and 'access_cnt' provide light-weight
+ * instrumentation for debugging register usage in the sample programs.
+ */
 typedef struct {
     uint64_t val;
     uint32_t last_writer_pc;
     uint32_t access_cnt;
 } gpr_t;
 
+/*
+ * Enumeration of the thirty-two 128-bit vector registers.  The indices match
+ * the architectural V0–V31 naming used in A64 assembly.
+ */
 typedef enum a64rf_vreg_idx {
     V0  = 0,  V1,  V2,  V3,
     V4,       V5,  V6,  V7,
@@ -38,22 +66,40 @@ typedef enum a64rf_vreg_idx {
     V24,      V25, V26, V27,
     V28,      V29, V30, V31,
 
-    VREG_IDX_MAX
+    VREG_IDX_MAX              /* Number of vector registers */
 } a64rf_vreg_idx_t;
 
 
+/*
+ * Representation of a 128-bit vector register.  The anonymous union exposes
+ * several common views (byte/halfword/word/doubleword).  Similar to gpr_t the
+ * extra fields are used to track which instruction last modified the register
+ * and how often it has been accessed.
+ */
 typedef struct {
-    union { uint8_t b[16]; uint16_t h[8]; uint32_t s[4]; uint64_t d[2];};
+    union {
+        uint8_t  b[16];  /* 16 × 8-bit elements  */
+        uint16_t h[8];   /* 8  × 16-bit elements */
+        uint32_t s[4];   /* 4  × 32-bit elements */
+        uint64_t d[2];   /* 2  × 64-bit elements */
+    };
     uint32_t last_writer_pc;
     uint32_t access_cnt;
 } vreg_t;
 
+/* Total number of vector registers. */
 #define VREG_COUNT   ((size_t)VREG_IDX_MAX)
 
 
+/*
+ * Aggregate snapshot of the CPU state.  The structure contains arrays of all
+ * general purpose and vector registers along with the stack pointer and the
+ * NZCV flags.  It is the primary object passed to the helper functions in
+ * this project.
+ */
 typedef struct {
-    gpr_t gpr[GPR_COUNT];
-    vreg_t vreg[VREG_COUNT];
+    gpr_t    gpr[GPR_COUNT];
+    vreg_t   vreg[VREG_COUNT];
     uint64_t sp;
     nzcv_t   nzcv;
 } a64rf_state_t;


### PR DESCRIPTION
## Summary
- add overview comment block in `a64rf_types.h`
- document register index enums
- explain NZCV union
- describe GPR and VREG structs
- comment on counts and the aggregate state structure

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f06b1a49c8329bc19e0406478c56b