### PR TITLE
Add umbrella header

### DIFF
--- a/include/a64rf.h
+++ b/include/a64rf.h
@@ -1,0 +1,15 @@
+#pragma once
+
+/* Aggregate header for the A64RF playground.  Including this file
+ * pulls in all public C interfaces so that user code only needs a
+ * single include directive.
+ */
+
+#include "a64rf_types.h"
+#include "a64rf_api.h"
+#include "a64rf_op.h"
+#include "a64rf_dump.h"
+#include "a64rf_snap.h"
+#include "print_state.h"
+#include "a64rf_offsets.h"
+

--- a/tests/example001.c
+++ b/tests/example001.c
@@ -3,9 +3,7 @@
 #include <string.h>
 #include <inttypes.h>
 
-#include "a64rf_types.h"
-#include "a64rf_api.h"
-#include "a64rf_op.h"
+#include "a64rf.h"
 
 
 

--- a/tests/example002.c
+++ b/tests/example002.c
@@ -3,9 +3,7 @@
 #include <string.h>
 #include <inttypes.h>
 
-#include "a64rf_types.h"
-#include "a64rf_api.h"
-#include "a64rf_op.h"
+#include "a64rf.h"
 
 
 

--- a/tests/example003.c
+++ b/tests/example003.c
@@ -3,9 +3,7 @@
 #include <string.h>
 #include <inttypes.h>
 
-#include "a64rf_types.h"
-#include "a64rf_api.h"
-#include "a64rf_op.h"
+#include "a64rf.h"
 
 
 int main(void)

--- a/tests/example004.c
+++ b/tests/example004.c
@@ -3,9 +3,7 @@
 #include <string.h>
 #include <inttypes.h>
 
-#include "a64rf_types.h"
-#include "a64rf_api.h"
-#include "a64rf_op.h"
+#include "a64rf.h"
 
 int main(void)
 {


### PR DESCRIPTION
## Summary
- add an aggregate `a64rf.h` header for easier inclusion
- update examples to include the umbrella header

## Testing
- `clang -Iinclude -c tests/example001.c -o /tmp/example001.o` *(fails: 'a64rf_state.h' file not found)*
- `for f in tests/example*.c; do clang -Iinclude -c $f -o /tmp/$(basename $f).o; done` *(fails: 'a64rf_state.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f10f7e1f483299141276815e49957